### PR TITLE
Replace deploy pages action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ jobs:
   generate_tile_job:
     runs-on: ubuntu-latest
     name: A job to generate vector tiles
+    permissions:
+     contents: write
     concurrency: 
       group: ${{ github.ref }} # 同じブランチで並列実行を防ぐ
       cancel-in-progress: true
@@ -21,7 +23,8 @@ jobs:
           out_dir: ./
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          branch: gh-pages
-          folder: ./
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 * `example.csv` を編集してコミットすると数分後に ベクトルタイルが生成されます。
   * csv の先頭行には、**必ず `緯度`、`経度`という項目を追加して下さい**
   * 任意のファイル名の CSV を1つのみ設置できます。
+  * ファイルの文字コードは UTF-8 を指定して下さい。
 * `https://<あなたのGitHubユーザー名>.github.io/<リポジトリ名>/tiles/tiles.json` をリクエスト用のURL（[例](https://geolonia.github.io/vector-tiles-api/tiles/tiles.json)）として利用する。
 
 ### GeoJSON データのご利用方法


### PR DESCRIPTION
`JamesIves/github-pages-deploy-action` を使用すると、別の CSV をアップロードした時に、Action 実行中に以下のエラーが起きるので、`peaceiris/actions-gh-pages@v3` を使用するように変更しました

```
Error: The deploy step encountered an error: The process '/usr/bin/rsync' failed with exit code 24 ❌
Notice: Deployment failed! ❌
```
エラーログ
https://github.com/naogify/vector-tiles-api-debug/actions/runs/3367078055/jobs/5584225987

## 新しいアクションに置き換えたサンプルリポジトリ
https://github.com/naogify/vector-tiles-api-debug